### PR TITLE
Fix watchOS crash on first login

### DIFF
--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
         "state": {
           "branch": "main",
-          "revision": "e382516bcf5997b5281dc734540fc89f58daad9e",
+          "revision": "25edf7f1abee2b85163ea90bdad5efcf07ff5b6e",
           "version": null
         }
       },

--- a/OCKSample/AppDelegate.swift
+++ b/OCKSample/AppDelegate.swift
@@ -90,7 +90,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 case .failure(let parseError):
                     switch parseError.code{
                     case .usernameTaken: //Account already exists for this username.
-                        User.login(username: newUser.username!, password: newUser.password!){ result in
+                        User.login(username: newUser.username!, password: newUser.password!, callbackQueue: .main) { result in
                                 
                             switch result {
                             

--- a/OCKSample/AppDelegate.swift
+++ b/OCKSample/AppDelegate.swift
@@ -79,7 +79,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             newUser.username = "ParseCareKit"
             newUser.password = "ThisIsAStrongPass1!"
             
-            newUser.signup { result in
+            newUser.signup(callbackQueue: .main) { result in
                 switch result {
                 
                 case .success(let user):
@@ -97,8 +97,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                             case .success(let user):
                                 print("Parse login successful \(user)")
                                 self.setupRemotes()
-                                self.coreDataStore.populateSampleData()
-                                self.healthKitStore.populateSampleData()
                             case .failure(let error):
                                 print("*** Error logging into Parse Server. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
                                 print("Parse error: \(String(describing: error))")

--- a/OCKWatchSample Extension/ExtensionDelegate.swift
+++ b/OCKWatchSample Extension/ExtensionDelegate.swift
@@ -50,32 +50,16 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             newUser.username = "ParseCareKit"
             newUser.password = "ThisIsAStrongPass1!"
             
-            newUser.signup{ result in
+            User.login(username: newUser.username!, password: newUser.password!, callbackQueue: .main) { result in
+                    
                 switch result {
                 
                 case .success(let user):
-                    print("Parse signup successful \(user)")
+                    print("Parse login successful \(user)")
                     self.setupRemotes()
-                case .failure(let parseError):
-                    switch parseError.code {
-                    case .usernameTaken:
-                        User.login(username: newUser.username!, password: newUser.password!) { result in
-                                
-                            switch result {
-                            
-                            case .success(let user):
-                                print("Parse login successful \(user)")
-                                self.setupRemotes()
-                            case .failure(let error):
-                                print("*** Error logging into Parse Server. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
-                                print("Parse error: \(String(describing: error))")
-                            }
-                        }
-                    default:
-                        //There was a different issue that we don't know how to handle
-                        print("*** Error Signing up as user for Parse Server. Are you running parse-postgres and is the initialization complete? Check http://localhost:1337 in your browser. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
-                        print(parseError)
-                    }
+                case .failure(let error):
+                    print("*** Error logging into Parse Server. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
+                    print("Parse error: \(String(describing: error))")
                 }
             }
             return
@@ -101,15 +85,15 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         
         WCSession.default.delegate = sessionDelegate
         WCSession.default.activate()
+        self.store.synchronize { error in
+            print(error?.localizedDescription ?? "Successful sync!")
+        }
     }
     
     func applicationDidBecomeActive() {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-        
-        if User.current != nil{
-            self.store.synchronize{error in
-                print(error?.localizedDescription ?? "Successful sync!")
-            }
+        self.store.synchronize{error in
+            print(error?.localizedDescription ?? "Successful sync!")
         }
     }
 


### PR DESCRIPTION
Only populateSampleData() on iOS on signUp, never during login.