### PR TITLE
Fixed watchOS sync with Cloud and watchOS sync with iPhone

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -11,14 +11,14 @@
 		5173CB8A23C3A846007655A0 /* OCKSampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173CB8923C3A846007655A0 /* OCKSampleUITests.swift */; };
 		70077597252228E900EC0EDA /* ParseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70077596252228E900EC0EDA /* ParseObjects.swift */; };
 		7007759B252229C900EC0EDA /* ParseObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70077596252228E900EC0EDA /* ParseObjects.swift */; };
-		701B28BF2552687700A702C0 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 701B28BE2552687700A702C0 /* ParseCareKit */; };
-		701B28C4255268AC00A702C0 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 701B28C3255268AC00A702C0 /* ParseCareKit */; };
 		707CC714254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC715254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC716254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
 		707CC717254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
 		707CC718254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
 		707CC719254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
+		709B97D62556298700507778 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 709B97D52556298700507778 /* ParseCareKit */; };
+		709B97DB2556299800507778 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 709B97DA2556299800507778 /* ParseCareKit */; };
 		70B3ABC22526B86C0066D0B9 /* CareKitFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 70B3ABC12526B86C0066D0B9 /* CareKitFHIR */; };
 		70B3ABC42526B86C0066D0B9 /* CareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70B3ABC32526B86C0066D0B9 /* CareKit */; };
 		70B3ABC62526B86C0066D0B9 /* CareKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 70B3ABC52526B86C0066D0B9 /* CareKitUI */; };
@@ -149,7 +149,7 @@
 			files = (
 				70B3ABC42526B86C0066D0B9 /* CareKit in Frameworks */,
 				70B3ABC62526B86C0066D0B9 /* CareKitUI in Frameworks */,
-				701B28BF2552687700A702C0 /* ParseCareKit in Frameworks */,
+				709B97D62556298700507778 /* ParseCareKit in Frameworks */,
 				70B3ABC22526B86C0066D0B9 /* CareKitFHIR in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,7 +167,7 @@
 			files = (
 				70B3ABCD2526B87D0066D0B9 /* CareKit in Frameworks */,
 				70B3ABCF2526B87D0066D0B9 /* CareKitUI in Frameworks */,
-				701B28C4255268AC00A702C0 /* ParseCareKit in Frameworks */,
+				709B97DB2556299800507778 /* ParseCareKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,7 +349,7 @@
 			packageProductDependencies = (
 				70B3ABCC2526B87D0066D0B9 /* CareKit */,
 				70B3ABCE2526B87D0066D0B9 /* CareKitUI */,
-				701B28C3255268AC00A702C0 /* ParseCareKit */,
+				709B97DA2556299800507778 /* ParseCareKit */,
 			);
 			productName = "OCKWatchSample Extension";
 			productReference = 91AD923324A4C42D00925D4D /* OCKWatchSample Extension.appex */;
@@ -375,7 +375,7 @@
 				70B3ABC12526B86C0066D0B9 /* CareKitFHIR */,
 				70B3ABC32526B86C0066D0B9 /* CareKit */,
 				70B3ABC52526B86C0066D0B9 /* CareKitUI */,
-				701B28BE2552687700A702C0 /* ParseCareKit */,
+				709B97D52556298700507778 /* ParseCareKit */,
 			);
 			productName = CareKitDemoApp;
 			productReference = E72B2C06226939E3009A9438 /* OCKSample.app */;
@@ -417,7 +417,7 @@
 			mainGroup = E72B2BFD226939E3009A9438;
 			packageReferences = (
 				70B3ABC02526B86C0066D0B9 /* XCRemoteSwiftPackageReference "CareKit" */,
-				701B28BD2552687700A702C0 /* XCRemoteSwiftPackageReference "ParseCareKit" */,
+				709B97D42556298700507778 /* XCRemoteSwiftPackageReference "ParseCareKit" */,
 			);
 			productRefGroup = E72B2C07226939E3009A9438 /* Products */;
 			projectDirPath = "";
@@ -984,7 +984,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		701B28BD2552687700A702C0 /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
+		709B97D42556298700507778 /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/netreconlab/ParseCareKit.git";
 			requirement = {
@@ -1003,14 +1003,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		701B28BE2552687700A702C0 /* ParseCareKit */ = {
+		709B97D52556298700507778 /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 701B28BD2552687700A702C0 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 709B97D42556298700507778 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
-		701B28C3255268AC00A702C0 /* ParseCareKit */ = {
+		709B97DA2556299800507778 /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 701B28BD2552687700A702C0 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 709B97D42556298700507778 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
 		70B3ABC12526B86C0066D0B9 /* CareKitFHIR */ = {

--- a/OCKSample/AppDelegate.swift
+++ b/OCKSample/AppDelegate.swift
@@ -40,7 +40,7 @@ import WatchConnectivity
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    private let syncWithCloud = true //True to sync with ParseServer, False to Sync with iOS Watch
+    let syncWithCloud = true //True to sync with ParseServer, False to Sync with iOS Watch
     var coreDataStore: OCKStore!
     let healthKitStore = OCKHealthKitPassthroughStore(name: "SampleAppHealthKitPassthroughStore", type: .inMemory)
     private var parse: ParseRemoteSynchronizationManager!
@@ -83,8 +83,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func setupRemotes() {
         do {
-            parse = try ParseRemoteSynchronizationManager(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: true)
+            
             if syncWithCloud{
+                parse = try ParseRemoteSynchronizationManager(uuid: UUID(uuidString: "3B5FD9DA-C278-4582-90DC-101C08E7FC98")!, auto: true)
                 coreDataStore = OCKStore(name: "SampleAppStore", type: .onDisk, remote: parse)
                 parse?.parseRemoteDelegate = self
                 sessionDelegate = CloudSyncSessionDelegate(store: coreDataStore)

--- a/OCKWatchSample Extension/ExtensionDelegate.swift
+++ b/OCKWatchSample Extension/ExtensionDelegate.swift
@@ -42,30 +42,35 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         } catch {
             print(error.localizedDescription)
         }
-        
-        //If the user isn't logged in, log them in
-        if User.current == nil {
-            
-            var newUser = User()
-            newUser.username = "ParseCareKit"
-            newUser.password = "ThisIsAStrongPass1!"
-            
-            User.login(username: newUser.username!, password: newUser.password!, callbackQueue: .main) { result in
-                    
-                switch result {
-                
-                case .success(let user):
-                    print("Parse login successful \(user)")
-                    self.setupRemotes()
-                case .failure(let error):
-                    print("*** Error logging into Parse Server. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
-                    print("Parse error: \(String(describing: error))")
-                }
-            }
-            return
+
+        //When syncing directly with watchOS, we don't care about login and need to setup remotes
+        if !syncWithCloud {
+            setupRemotes()
         } else {
-            self.setupRemotes()
-            print("User is already signed in...")
+            //If the user isn't logged in, log them in
+            if User.current == nil {
+                
+                var newUser = User()
+                newUser.username = "ParseCareKit"
+                newUser.password = "ThisIsAStrongPass1!"
+                
+                User.login(username: newUser.username!, password: newUser.password!) { result in
+                        
+                    switch result {
+                    
+                    case .success(let user):
+                        print("Parse login successful \(user)")
+                        DispatchQueue.main.async { self.setupRemotes() }
+                    case .failure(let error):
+                        print("*** Error logging into Parse Server. If you are still having problems check for help here: https://github.com/netreconlab/parse-hipaa#getting-started ***")
+                        print("Parse error: \(String(describing: error))")
+                    }
+                }
+                return
+            } else {
+                self.setupRemotes()
+                print("User is already signed in...")
+            }
         }
     }
 


### PR DESCRIPTION
Fixed some threading issues that was causing problems with watchOS syncs. For the first time data can be both synced from:
- [x] watchOS <-> Parse, iPhone <-> Parse, watchOS <-> iPhone (indirect sync through Parse)
- [x] watchOS <-> iPhone (direct sync, switch `syncWithCloud = false` in `AppDelegate.swift` and `ExtensionDelegate.swift`