### PR TITLE
Add LiveQuery support and sync progress

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -24,14 +24,14 @@
 		7036E68925731AD1006E9A3C /* CareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E68825731AD1006E9A3C /* CareKit */; };
 		7036E68B25731AD1006E9A3C /* CareKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E68A25731AD1006E9A3C /* CareKitUI */; };
 		7036E69C25731C12006E9A3C /* CareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E69B25731C12006E9A3C /* CareKit */; };
-		70572622258EB81700F0ADD5 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70572621258EB81700F0ADD5 /* ParseCareKit */; };
-		7057262A258EB83200F0ADD5 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70572629258EB83200F0ADD5 /* ParseCareKit */; };
 		707CC714254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC715254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC716254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
 		707CC717254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
 		707CC718254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
 		707CC719254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
+		709EE96525AD0612009C9F1D /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 709EE96425AD0612009C9F1D /* ParseCareKit */; };
+		709EE96A25AD0670009C9F1D /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 709EE96925AD0670009C9F1D /* ParseCareKit */; };
 		70DFD80B2567074500B9DB12 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BD2B1E254B44DB0030B424 /* LoginView.swift */; };
 		91AD922224A45A3900925D4D /* ParseCareKit.plist in Resources */ = {isa = PBXBuildFile; fileRef = 91AD922124A45A3900925D4D /* ParseCareKit.plist */; };
 		91AD922424A461D200925D4D /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 91AD922324A461D200925D4D /* README.md */; };
@@ -168,7 +168,7 @@
 			files = (
 				7036E68925731AD1006E9A3C /* CareKit in Frameworks */,
 				7036E68725731AD1006E9A3C /* CareKitFHIR in Frameworks */,
-				70572622258EB81700F0ADD5 /* ParseCareKit in Frameworks */,
+				709EE96525AD0612009C9F1D /* ParseCareKit in Frameworks */,
 				7036E68B25731AD1006E9A3C /* CareKitUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -184,7 +184,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7057262A258EB83200F0ADD5 /* ParseCareKit in Frameworks */,
+				709EE96A25AD0670009C9F1D /* ParseCareKit in Frameworks */,
 				7036E69C25731C12006E9A3C /* CareKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -416,7 +416,7 @@
 			name = "OCKWatchSample Extension";
 			packageProductDependencies = (
 				7036E69B25731C12006E9A3C /* CareKit */,
-				70572629258EB83200F0ADD5 /* ParseCareKit */,
+				709EE96925AD0670009C9F1D /* ParseCareKit */,
 			);
 			productName = "OCKWatchSample Extension";
 			productReference = 91AD923324A4C42D00925D4D /* OCKWatchSample Extension.appex */;
@@ -442,7 +442,7 @@
 				7036E68625731AD1006E9A3C /* CareKitFHIR */,
 				7036E68825731AD1006E9A3C /* CareKit */,
 				7036E68A25731AD1006E9A3C /* CareKitUI */,
-				70572621258EB81700F0ADD5 /* ParseCareKit */,
+				709EE96425AD0612009C9F1D /* ParseCareKit */,
 			);
 			productName = CareKitDemoApp;
 			productReference = E72B2C06226939E3009A9438 /* OCKSample.app */;
@@ -484,7 +484,7 @@
 			mainGroup = E72B2BFD226939E3009A9438;
 			packageReferences = (
 				7036E68525731AD1006E9A3C /* XCRemoteSwiftPackageReference "CareKit" */,
-				70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */,
+				709EE96325AD0612009C9F1D /* XCRemoteSwiftPackageReference "ParseCareKit" */,
 			);
 			productRefGroup = E72B2C07226939E3009A9438 /* Products */;
 			projectDirPath = "";
@@ -1073,7 +1073,7 @@
 				kind = branch;
 			};
 		};
-		70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
+		709EE96325AD0612009C9F1D /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/netreconlab/ParseCareKit.git";
 			requirement = {
@@ -1104,14 +1104,14 @@
 			package = 7036E68525731AD1006E9A3C /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKit;
 		};
-		70572621258EB81700F0ADD5 /* ParseCareKit */ = {
+		709EE96425AD0612009C9F1D /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 709EE96325AD0612009C9F1D /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
-		70572629258EB83200F0ADD5 /* ParseCareKit */ = {
+		709EE96925AD0670009C9F1D /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 709EE96325AD0612009C9F1D /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -24,8 +24,8 @@
 		7036E68925731AD1006E9A3C /* CareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E68825731AD1006E9A3C /* CareKit */; };
 		7036E68B25731AD1006E9A3C /* CareKitUI in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E68A25731AD1006E9A3C /* CareKitUI */; };
 		7036E69C25731C12006E9A3C /* CareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7036E69B25731C12006E9A3C /* CareKit */; };
-		70640F50258BC1AF00999BB8 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70640F4F258BC1AF00999BB8 /* ParseCareKit */; };
-		70640F55258BC2C400999BB8 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70640F54258BC2C400999BB8 /* ParseCareKit */; };
+		70572622258EB81700F0ADD5 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70572621258EB81700F0ADD5 /* ParseCareKit */; };
+		7057262A258EB83200F0ADD5 /* ParseCareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70572629258EB83200F0ADD5 /* ParseCareKit */; };
 		707CC714254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC715254DA91900116728 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 707CC70F254DA91900116728 /* Localizable.strings */; };
 		707CC716254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
@@ -168,7 +168,7 @@
 			files = (
 				7036E68925731AD1006E9A3C /* CareKit in Frameworks */,
 				7036E68725731AD1006E9A3C /* CareKitFHIR in Frameworks */,
-				70640F50258BC1AF00999BB8 /* ParseCareKit in Frameworks */,
+				70572622258EB81700F0ADD5 /* ParseCareKit in Frameworks */,
 				7036E68B25731AD1006E9A3C /* CareKitUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -184,7 +184,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70640F55258BC2C400999BB8 /* ParseCareKit in Frameworks */,
+				7057262A258EB83200F0ADD5 /* ParseCareKit in Frameworks */,
 				7036E69C25731C12006E9A3C /* CareKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -416,7 +416,7 @@
 			name = "OCKWatchSample Extension";
 			packageProductDependencies = (
 				7036E69B25731C12006E9A3C /* CareKit */,
-				70640F54258BC2C400999BB8 /* ParseCareKit */,
+				70572629258EB83200F0ADD5 /* ParseCareKit */,
 			);
 			productName = "OCKWatchSample Extension";
 			productReference = 91AD923324A4C42D00925D4D /* OCKWatchSample Extension.appex */;
@@ -442,7 +442,7 @@
 				7036E68625731AD1006E9A3C /* CareKitFHIR */,
 				7036E68825731AD1006E9A3C /* CareKit */,
 				7036E68A25731AD1006E9A3C /* CareKitUI */,
-				70640F4F258BC1AF00999BB8 /* ParseCareKit */,
+				70572621258EB81700F0ADD5 /* ParseCareKit */,
 			);
 			productName = CareKitDemoApp;
 			productReference = E72B2C06226939E3009A9438 /* OCKSample.app */;
@@ -484,7 +484,7 @@
 			mainGroup = E72B2BFD226939E3009A9438;
 			packageReferences = (
 				7036E68525731AD1006E9A3C /* XCRemoteSwiftPackageReference "CareKit" */,
-				70640F4E258BC1AF00999BB8 /* XCRemoteSwiftPackageReference "ParseCareKit" */,
+				70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */,
 			);
 			productRefGroup = E72B2C07226939E3009A9438 /* Products */;
 			projectDirPath = "";
@@ -1073,7 +1073,7 @@
 				kind = branch;
 			};
 		};
-		70640F4E258BC1AF00999BB8 /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
+		70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/netreconlab/ParseCareKit.git";
 			requirement = {
@@ -1104,14 +1104,14 @@
 			package = 7036E68525731AD1006E9A3C /* XCRemoteSwiftPackageReference "CareKit" */;
 			productName = CareKit;
 		};
-		70640F4F258BC1AF00999BB8 /* ParseCareKit */ = {
+		70572621258EB81700F0ADD5 /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 70640F4E258BC1AF00999BB8 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
-		70640F54258BC2C400999BB8 /* ParseCareKit */ = {
+		70572629258EB83200F0ADD5 /* ParseCareKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 70640F4E258BC1AF00999BB8 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
+			package = 70572620258EB81600F0ADD5 /* XCRemoteSwiftPackageReference "ParseCareKit" */;
 			productName = ParseCareKit;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
           "branch": "main",
-          "revision": "4936c622d55d876ccf43d7a4f4fa6acdf4db6747",
+          "revision": "56796e8c7915b5813a47f54d746219a29685cb81",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": "main",
-          "revision": "e2dde15dc6d9655498521edba6d676d49de71d51",
+          "revision": "806e0269f62730234fe3ca7ed5c2f865f2a6f374",
           "version": null
         }
       },
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/netreconlab/ParseCareKit.git",
         "state": {
           "branch": "main",
-          "revision": "7cce16663e2ea5f2719af6195e40ba687acba74c",
+          "revision": "78318d5f7d41e93b899fbb50eee70de787c41e19",
           "version": null
         }
       }

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/carekit-apple/CareKit.git",
         "state": {
           "branch": "main",
-          "revision": "f892a5e0036b044e7e0309ae05912e29f5cdce8d",
+          "revision": "4936c622d55d876ccf43d7a4f4fa6acdf4db6747",
           "version": null
         }
       },
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/parse-community/Parse-Swift",
         "state": {
           "branch": "main",
-          "revision": "ea76851b880fc1d65bc657318555c9542282f8ad",
+          "revision": "e2dde15dc6d9655498521edba6d676d49de71d51",
           "version": null
         }
       },
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/netreconlab/ParseCareKit.git",
         "state": {
           "branch": "main",
-          "revision": "243efa01447580a011fcfe44bb6f48ba91b1494d",
+          "revision": "7cce16663e2ea5f2719af6195e40ba687acba74c",
           "version": null
         }
       }

--- a/OCKSample/Constants.swift
+++ b/OCKSample/Constants.swift
@@ -28,5 +28,6 @@ enum Constants {
     static let parseUserKey = "requestParseUser"
     static let parseRemoteClockIDKey = "requestRemoteClockID"
     static let requestSync = "requestSync"
+    static let progressUpdate = "progressUpdate"
 }
 


### PR DESCRIPTION
- [x] Add LiveQuery support for automatic updates across user devices. Each user device automatically subscribes to receive updates across devices using [LiveQuery](https://github.com/parse-community/Parse-Swift#livequery). Be sure to use the latest [parse-hipaa](https://github.com/netreconlab/parse-hipaa) which will enable server-side.
- [x] The `CareViewController` now shows sync progress on the top right
- [x] Updated dependences to latest: ParseCareKit, Parse-Swift, CareKit  