### PR TITLE
fix: server check should properly use async/await

### DIFF
--- a/OCKSample/Extensions/PCKUtility+extention.swift
+++ b/OCKSample/Extensions/PCKUtility+extention.swift
@@ -17,8 +17,8 @@ extension PCKUtility {
      - returns: **true** if the server is available. **false** if the server reponds with not healthy.
      - throws: `ParseError`.
      */
-    static func isServerAvailable() throws -> Bool {
-        let serverHealth = try ParseHealth.check()
+    static func isServerAvailable() async throws -> Bool {
+        let serverHealth = try await ParseHealth.check()
         guard serverHealth.contains("ok") else {
             return false
         }

--- a/OCKSample/Login/LoginViewModel.swift
+++ b/OCKSample/Login/LoginViewModel.swift
@@ -107,7 +107,7 @@ class LoginViewModel: ObservableObject {
                 lastName: String) async {
 
         do {
-            guard try PCKUtility.isServerAvailable() else {
+            guard try await PCKUtility.isServerAvailable() else {
                 Logger.login.error("Server health is not \"ok\"")
                 return
             }
@@ -149,7 +149,7 @@ class LoginViewModel: ObservableObject {
     func login(username: String, password: String) async {
 
         do {
-            guard try PCKUtility.isServerAvailable() else {
+            guard try await PCKUtility.isServerAvailable() else {
                 Logger.login.error("Server health is not \"ok\"")
                 return
             }
@@ -181,7 +181,7 @@ class LoginViewModel: ObservableObject {
     func loginAnonymously() async {
 
         do {
-            guard try PCKUtility.isServerAvailable() else {
+            guard try await PCKUtility.isServerAvailable() else {
                 Logger.login.error("Server health is not \"ok\"")
                 return
             }

--- a/OCKSample/MainTabs/Care/CareViewController.swift
+++ b/OCKSample/MainTabs/Care/CareViewController.swift
@@ -117,23 +117,26 @@ class CareViewController: OCKDailyPageViewController {
             isSyncing = true
         }
 
-        // swiftlint:disable:next force_cast
-        let appDelegate = UIApplication.shared.delegate as! AppDelegate
-        appDelegate.store.synchronize { error in
+        DispatchQueue.main.async {
+            
+            // swiftlint:disable:next force_cast
+            let appDelegate = UIApplication.shared.delegate as! AppDelegate
+            appDelegate.store.synchronize { error in
 
-            DispatchQueue.main.async {
-                let errorString = error?.localizedDescription ?? "Successful sync with remote!"
-                Logger.feed.info("\(errorString)")
-                if error != nil {
-                    self.navigationItem.rightBarButtonItem?.tintColor = .red
-                } else {
-                    // swiftlint:disable:next force_cast
-                    let appDelegate = UIApplication.shared.delegate as! AppDelegate
-                    if appDelegate.isFirstAppOpen {
-                        self.reloadView()
+                DispatchQueue.main.async {
+                    let errorString = error?.localizedDescription ?? "Successful sync with remote!"
+                    Logger.feed.info("\(errorString)")
+                    if error != nil {
+                        self.navigationItem.rightBarButtonItem?.tintColor = .red
+                    } else {
+                        // swiftlint:disable:next force_cast
+                        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+                        if appDelegate.isFirstAppOpen {
+                            self.reloadView()
+                        }
                     }
+                    self.isSyncing = false
                 }
-                self.isSyncing = false
             }
         }
     }


### PR DESCRIPTION
Users can have trouble connecting to server because of bug in the code.

## PR addresses
- [x] The server check not properly
- [x] Fix a problem where UI call was made on a background thread 

## How to apply fixes manually

1. Create a new branch in Xcode called, `fixNetwork`
2. To fix the problem, do the following:

```swift
// Open Xcode and go to: OCKSample/Extensions/PCKUtility+extention.swift

// Add the word "async" to line 20
// Old

static func isServerAvailable() throws -> Bool 

// New 
static func isServerAvailable() async throws -> Bool

// Build Xcode, this should trigger three errors in: OCKSample/Login/LoginViewModel.swift
// In a similar manner, add "async" to lines:

// Lines 110, 152, and 184:

// Old
guard try PCKUtility.isServerAvailable() else

// New
guard try await PCKUtility.isServerAvailable() else
```

Build your project and make sure it builds successfully. Next go to: OCKSample/MainTabs/Care/CareViewController.swift

Delete the lines below:
https://github.com/netreconlab/CareKitSample-ParseCareKit/blob/b99fcdd55cbdaa82a2d63ed37eb01967888e9c60/OCKSample/MainTabs/Care/CareViewController.swift#L120-L138

and replace them with:

```swift
DispatchQueue.main.async {
            
            // swiftlint:disable:next force_cast
            let appDelegate = UIApplication.shared.delegate as! AppDelegate
            appDelegate.store.synchronize { error in

                DispatchQueue.main.async {
                    let errorString = error?.localizedDescription ?? "Successful sync with remote!"
                    Logger.feed.info("\(errorString)")
                    if error != nil {
                        self.navigationItem.rightBarButtonItem?.tintColor = .red
                    } else {
                        // swiftlint:disable:next force_cast
                        let appDelegate = UIApplication.shared.delegate as! AppDelegate
                        if appDelegate.isFirstAppOpen {
                            self.reloadView()
                        }
                    }
                    self.isSyncing = false
                }
            }
        }
```