### PR TITLE
fix: build for Xcode13.3

### DIFF
--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,43 +1,39 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "CareKit",
-        "repositoryURL": "https://github.com/carekit-apple/CareKit",
-        "state": {
-          "branch": null,
-          "revision": "a612482e4ba4f28d4c75129c0a9b70ca23098bd6",
-          "version": null
-        }
-      },
-      {
-        "package": "FHIRModels",
-        "repositoryURL": "https://github.com/apple/FHIRModels.git",
-        "state": {
-          "branch": null,
-          "revision": "c91e5bb74397136f79656bebdfda76a523d3e88c",
-          "version": "0.3.2"
-        }
-      },
-      {
-        "package": "ParseSwift",
-        "repositoryURL": "https://github.com/parse-community/Parse-Swift.git",
-        "state": {
-          "branch": null,
-          "revision": "51e16d0764bc5f65b0b78b982b2c4febff421818",
-          "version": "4.0.1"
-        }
-      },
-      {
-        "package": "ParseCareKit",
-        "repositoryURL": "https://github.com/netreconlab/ParseCareKit.git",
-        "state": {
-          "branch": null,
-          "revision": "8e41f650b5bb71e772eb99238a20884f1f98b61d",
-          "version": null
-        }
+  "pins" : [
+    {
+      "identity" : "carekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/carekit-apple/CareKit",
+      "state" : {
+        "revision" : "a612482e4ba4f28d4c75129c0a9b70ca23098bd6"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "fhirmodels",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/FHIRModels.git",
+      "state" : {
+        "revision" : "c91e5bb74397136f79656bebdfda76a523d3e88c",
+        "version" : "0.3.2"
+      }
+    },
+    {
+      "identity" : "parse-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/parse-community/Parse-Swift.git",
+      "state" : {
+        "revision" : "51e16d0764bc5f65b0b78b982b2c4febff421818",
+        "version" : "4.0.1"
+      }
+    },
+    {
+      "identity" : "parsecarekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/netreconlab/ParseCareKit.git",
+      "state" : {
+        "revision" : "8e41f650b5bb71e772eb99238a20884f1f98b61d"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/OCKSample/Login/LoginViewModel.swift
+++ b/OCKSample/Login/LoginViewModel.swift
@@ -15,7 +15,6 @@ import CareKitStore
 import WatchConnectivity
 import os.log
 
-@MainActor
 class LoginViewModel: ObservableObject {
 
     @Published private(set) var isLoggedOut = true {
@@ -33,7 +32,7 @@ class LoginViewModel: ObservableObject {
     private let profileViewModel: ProfileViewModel = ProfileViewModelKey.defaultValue
 
     // MARK: Helpers
-
+    @MainActor
     private func finishCompletingSignIn(_ careKitPatient: OCKPatient? = nil) async throws {
 
         if let careKitUser = careKitPatient {

--- a/OCKSample/MainTabs/Care/CareViewModel.swift
+++ b/OCKSample/MainTabs/Care/CareViewModel.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@MainActor
 class CareViewModel: ObservableObject {
     @Published var update = false
 

--- a/OCKSample/MainTabs/Profile/ProfileViewModel.swift
+++ b/OCKSample/MainTabs/Profile/ProfileViewModel.swift
@@ -15,7 +15,6 @@ import UIKit
 import os.log
 import Combine
 
-@MainActor
 class ProfileViewModel: ObservableObject {
 
     @Published var patient: OCKPatient?
@@ -119,6 +118,7 @@ class ProfileViewModel: ObservableObject {
         return remoteClockUUID
     }
 
+    @MainActor
     static func setupRemoteAfterLoginButtonTapped() async throws {
 
         let remoteUUID = try await Self.getRemoteClockUUIDAfterLoginFromCloud()
@@ -197,6 +197,7 @@ class ProfileViewModel: ObservableObject {
         }
     }
 
+    @MainActor
     static func savePatientAfterSignUp(_ type: UserType, first: String, last: String) async throws -> OCKPatient {
 
         let remoteUUID = UUID()
@@ -239,6 +240,7 @@ class ProfileViewModel: ObservableObject {
     // You may not have seen "throws" before, but it's simple,
     // this throws an error if one occurs, if not it behaves as normal
     // Normally, you've seen do {} catch{} which catches the error, same concept...
+    @MainActor
     func logout() async {
         do {
             try await User.logout()

--- a/OCKSample/ViewModels/UserStatus.swift
+++ b/OCKSample/ViewModels/UserStatus.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-@MainActor
 class UserStatus: ObservableObject {
     @Published var isLoggedOut = true
 

--- a/OCKWatchSample Extension/Care/CareView.swift
+++ b/OCKWatchSample Extension/Care/CareView.swift
@@ -51,6 +51,12 @@ struct CareView: View {
             }
         })
     }
+    /*
+    init() {
+        self._loginViewModel = StateObject(wrappedValue: LoginViewModel())
+        self._viewModel = StateObject(wrappedValue: CareViewModel())
+        self._userStatus = StateObject(wrappedValue: UserStatus())
+    }*/
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/OCKWatchSample Extension/Care/CareView.swift
+++ b/OCKWatchSample Extension/Care/CareView.swift
@@ -51,12 +51,6 @@ struct CareView: View {
             }
         })
     }
-    /*
-    init() {
-        self._loginViewModel = StateObject(wrappedValue: LoginViewModel())
-        self._viewModel = StateObject(wrappedValue: CareViewModel())
-        self._userStatus = StateObject(wrappedValue: UserStatus())
-    }*/
 }
 
 struct ContentView_Previews: PreviewProvider {

--- a/OCKWatchSample Extension/Care/CareViewModel.swift
+++ b/OCKWatchSample Extension/Care/CareViewModel.swift
@@ -13,7 +13,6 @@ import CareKitStore
 import WatchConnectivity
 import os.log
 
-@MainActor
 class CareViewModel: ObservableObject {
     @Published var update = false
     @Published var storeManager: OCKSynchronizedStoreManager

--- a/OCKWatchSample Extension/Login/LoginViewModel.swift
+++ b/OCKWatchSample Extension/Login/LoginViewModel.swift
@@ -11,10 +11,8 @@ import CareKit
 import ParseSwift
 import os.log
 
-@MainActor
 class LoginViewModel: ObservableObject {
-    // swiftlint:disable:next force_cast
-    private let watchDelegate = WKExtension.shared().delegate as! ExtensionDelegate
+    private let watchDelegate: ExtensionDelegate
 
     var syncWithCloud: Bool {
         return watchDelegate.syncWithCloud
@@ -23,6 +21,8 @@ class LoginViewModel: ObservableObject {
     @Published var isLoggedOut = true
 
     init() {
+        // swiftlint:disable:next force_cast
+        self.watchDelegate = WKExtension.shared().delegate as! ExtensionDelegate
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(userLoggedIn(_:)),
                                                name: Notification.Name(rawValue: Constants.userLoggedIn),
@@ -42,6 +42,7 @@ class LoginViewModel: ObservableObject {
         _ = try ParseACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
     }
 
+    @MainActor
     class func loginFromiPhoneMessage(_ message: [String: Any]) async {
         guard let sessionToken = message[Constants.parseUserSessionTokenKey] as? String,
               let uuidString = message[Constants.parseRemoteClockIDKey] as? String else {


### PR DESCRIPTION
Xcode 13.6 has some preparation for Swift 6 which produces some bugs that need to be fixed in the app. 

1. Be sure to upgrade to the latest SwiftLint to be compatible with Xcode 13.3. In your terminal, type `brew upgrade swiftlint`
2. Either merge this PR into your repo or make the `@MainActor` changes manually [here](https://github.com/netreconlab/CareKitSample-ParseCareKit/pull/89/files)
    - Ignore the changes in `Package.resolved`