### PR TITLE
feat: Update ParseCareKit

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -1221,7 +1221,7 @@
 			repositoryURL = "https://github.com/netreconlab/ParseCareKit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.11.0;
+				version = 0.11.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/Parse-Swift.git",
       "state" : {
-        "revision" : "9e7f393744108c796d89be9c91101d106d7ddc67",
-        "version" : "5.0.0-beta.7"
+        "revision" : "fd285005023271e615062cfad1d92261ee55fe4b",
+        "version" : "5.0.0-beta.9"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/ParseCareKit.git",
       "state" : {
-        "revision" : "d83dff408bddcc588e5066c5424bac23a35d21ca",
-        "version" : "0.11.0"
+        "revision" : "545e4ac3601e1381dafbe8073a39344919de7500",
+        "version" : "0.11.1"
       }
     }
   ],


### PR DESCRIPTION
Update ParseCareKit to latest to take advantage of latest ParseSwift beta