### PR TITLE
fix: Care and Profile view won't show data on first login

### DIFF
--- a/OCKSample/AppDelegate.swift
+++ b/OCKSample/AppDelegate.swift
@@ -38,7 +38,13 @@ import WatchConnectivity
 
 class AppDelegate: UIResponder, ObservableObject {
     // MARK: Public read/write properties
-    var isFirstTimeLogin = false
+    @Published var isFirstTimeLogin = false {
+        willSet {
+            DispatchQueue.main.async {
+                self.objectWillChange.send()
+            }
+        }
+    }
 
     // MARK: Public read private write properties
     // swiftlint:disable:next line_length

--- a/OCKSample/Extensions/AppDelegate+ParseRemoteDelegate.swift
+++ b/OCKSample/Extensions/AppDelegate+ParseRemoteDelegate.swift
@@ -19,7 +19,9 @@ extension AppDelegate: ParseRemoteDelegate {
 
     func successfullyPushedDataToCloud() {
         if isFirstTimeLogin {
-            isFirstTimeLogin.toggle()
+            DispatchQueue.main.async {
+                self.isFirstTimeLogin.toggle()
+            }
         }
         #if !targetEnvironment(simulator)
         // watchOS 9 needs to be sent messages for updates on real devices

--- a/OCKSample/Main/Login/LoginViewModel.swift
+++ b/OCKSample/Main/Login/LoginViewModel.swift
@@ -185,7 +185,7 @@ class LoginViewModel: ObservableObject {
 
             default:
                 // swiftlint:disable:next line_length
-                Logger.login.error("*** Error Signing up as user for Parse Server. Are you running parse-hipaa and is the initialization complete? Check http://localhost:1337 in your browser. If you are still having problems check for help here: https://github.com/netreconlab/parse-postgres#getting-started ***.")
+                Logger.login.error("*** Error Signing up as user for Parse Server. Are you running parse-hipaa and is the initialization complete? Check http://localhost:1337 in your browser. If you are still having problems check for help here: https://github.com/netreconlab/parse-postgres#getting-started ***")
                 self.loginError = parseError
             }
         }

--- a/OCKSample/Main/Profile/ProfileView.swift
+++ b/OCKSample/Main/Profile/ProfileView.swift
@@ -86,6 +86,8 @@ struct ProfileView: View {
             }
         }.onReceive(appDelegate.$storeManager) { newStoreManager in
             viewModel.updateStoreManager(newStoreManager)
+        }.onReceive(appDelegate.$isFirstTimeLogin) { _ in
+            viewModel.updateStoreManager()
         }
     }
 }

--- a/OCKSample/Main/Profile/ProfileViewModel.swift
+++ b/OCKSample/Main/Profile/ProfileViewModel.swift
@@ -41,7 +41,14 @@ class ProfileViewModel: ObservableObject {
         }
     }
 
-    func updateStoreManager(_ storeManager: OCKSynchronizedStoreManager) {
+    func updateStoreManager(_ storeManager: OCKSynchronizedStoreManager? = nil) {
+        guard let storeManager = storeManager else {
+            guard let appDelegateStoreManager = AppDelegateKey.defaultValue?.storeManager else {
+                return
+            }
+            self.storeManager = appDelegateStoreManager
+            return
+        }
         self.storeManager = storeManager
     }
 

--- a/OCKSample/Main/Profile/ProfileViewModel.swift
+++ b/OCKSample/Main/Profile/ProfileViewModel.swift
@@ -44,6 +44,7 @@ class ProfileViewModel: ObservableObject {
     func updateStoreManager(_ storeManager: OCKSynchronizedStoreManager? = nil) {
         guard let storeManager = storeManager else {
             guard let appDelegateStoreManager = AppDelegateKey.defaultValue?.storeManager else {
+                Logger.profile.error("Missing AppDelegate storeManager")
                 return
             }
             self.storeManager = appDelegateStoreManager
@@ -55,7 +56,7 @@ class ProfileViewModel: ObservableObject {
     @MainActor
     private func findAndObserveCurrentProfile() async {
         guard let uuid = try? await Utility.getRemoteClockUUID() else {
-            Logger.profile.error("Could not get remote uuid for this user.")
+            Logger.profile.error("Could not get remote uuid for this user")
             return
         }
         clearSubscriptions()
@@ -69,7 +70,7 @@ class ProfileViewModel: ObservableObject {
             let foundPatient = try await storeManager.store.fetchAnyPatients(query: queryForCurrentPatient)
             guard let currentPatient = foundPatient.first as? OCKPatient else {
                 // swiftlint:disable:next line_length
-                Logger.profile.error("Could not find patient with id \"\(uuid)\". It's possible they have never been saved.")
+                Logger.profile.error("Could not find patient with id \"\(uuid)\". It's possible they have never been saved")
                 return
             }
             self.observePatient(currentPatient)

--- a/OCKWatchSample Extension/Extensions/AppDelegate+ParseRemoteDelegate.swift
+++ b/OCKWatchSample Extension/Extensions/AppDelegate+ParseRemoteDelegate.swift
@@ -21,7 +21,7 @@ extension AppDelegate: ParseRemoteDelegate {
     }
 
     func successfullyPushedDataToCloud() {
-        Logger.appDelegate.info("Finished pushing data.")
+        Logger.appDelegate.info("Finished pushing data")
     }
 
     func remote(_ remote: OCKRemoteSynchronizable, didUpdateProgress progress: Double) {}

--- a/OCKWatchSample Extension/Main/Care/CareViewModel.swift
+++ b/OCKWatchSample Extension/Main/Care/CareViewModel.swift
@@ -17,7 +17,7 @@ class CareViewModel: ObservableObject {
 
     func synchronizeStore(storeManager: OCKSynchronizedStoreManager?) {
         guard let store = storeManager?.store as? OCKStore else {
-            Logger.feed.info("Could not cast to OCKStore.")
+            Logger.feed.info("Could not cast to OCKStore")
             return
         }
         store.synchronize { error in


### PR DESCRIPTION
There was a bug introduced after updating to ParseCareKit 0.12.0 where a user who re-logs into the app can't see data on their CareView and ProfileView until after closing and opening the app.

- [x] Publish changes to views after app login 