### PR TITLE
Update App Transport Secuirty Settings for Xcode 14.3

### DIFF
--- a/OCKSample/Supporting Files/Info.plist
+++ b/OCKSample/Supporting Files/Info.plist
@@ -30,7 +30,11 @@
 		<dict>
 			<key>localhost</key>
 			<dict>
-				<key>NSAllowsArbitraryLoads</key>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
 		</dict>

--- a/OCKWatchSample Extension/Info.plist
+++ b/OCKWatchSample Extension/Info.plist
@@ -28,8 +28,12 @@
         <dict>
             <key>localhost</key>
             <dict>
-                <key>NSAllowsArbitraryLoads</key>
+                <key>NSIncludesSubdomains</key>
                 <true/>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSExceptionRequiresForwardSecrecy</key>
+                <false/>
             </dict>
         </dict>
     </dict>

--- a/OCKWatchSample/Info.plist
+++ b/OCKWatchSample/Info.plist
@@ -28,8 +28,12 @@
 		<dict>
 			<key>localhost</key>
 			<dict>
-				<key>NSAllowsArbitraryLoads</key>
+				<key>NSIncludesSubdomains</key>
 				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
Greetings! I was trying to run the project on a locally hosted ParserKit server but noticed that iOS would now allow the app to connect to it, due to the App Transport Security settings that blocks connections to `http` endpoints. The settings that were currently on the project weren't seem to be working on the latest version of Xcode (14.3.1) so I've updated them in order to get it back working on my end

I'm submitting this pull request in order to get it working for others that would like to give this project a try as well. If you have any suggestions feel free to reach out! Thanks for all your work