### PR TITLE
fix: Build for earlier deployment targets by updating CareKitEssentials

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -937,12 +937,12 @@
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/OCKSample/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.usc.netrecon.ParseCarekitSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -952,7 +952,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 2.0;
+				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Release;
 		};
@@ -1066,7 +1066,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -1092,7 +1092,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 11.0;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1179,12 +1179,12 @@
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				INFOPLIST_FILE = "$(SRCROOT)/OCKSample/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = edu.usc.netrecon.ParseCarekitSample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1194,7 +1194,7 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
-				XROS_DEPLOYMENT_TARGET = 2.0;
+				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Debug;
 		};
@@ -1245,7 +1245,7 @@
 			repositoryURL = "https://github.com/netreconlab/CareKitEssentials";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "1.0.0-alpha.34";
+				minimumVersion = "1.0.0-alpha.35";
 			};
 		};
 		70202EBF2807333900CF73FB /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/CareKitEssentials",
       "state" : {
-        "revision" : "5c1535887bb9d567a5a084820e6d3c7a87864acd",
-        "version" : "1.0.0-alpha.34"
+        "revision" : "6e9cb497b977433fa5b862c14b0405838898132a",
+        "version" : "1.0.0-alpha.35"
       }
     },
     {

--- a/OCKSample/Main/Care/CustomCards/TipView.swift
+++ b/OCKSample/Main/Care/CustomCards/TipView.swift
@@ -32,7 +32,6 @@ import UIKit
 import CareKit
 import CareKitUI
 
-// swiftlint:disable line_length
 class TipView: OCKView, OCKCardable {
 
     var cardView: UIView { self }
@@ -97,19 +96,19 @@ class TipView: OCKView, OCKCardable {
             imageHeightConstraint
         ])
 
-        // BAKER: Required if building for iOS 18+.
-        /*
-        registerForTraitChanges(
-            [UITraitPreferredContentSizeCategory.self],
-            handler: { (self: Self, previousTraitCollection: UITraitCollection) in
-                let traitCollection = self.traitCollection
-                // swiftlint:disable:next line_length
-                if previousTraitCollection.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-                    self.imageHeightConstraint.constant = self.scaledImageHeight(compatibleWith: traitCollection)
+        // BAKER: Required if building for iOS 17+.
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges(
+                [UITraitPreferredContentSizeCategory.self],
+                handler: { (self: Self, previousTraitCollection: UITraitCollection) in
+                    let traitCollection = self.traitCollection
+                    // swiftlint:disable:next line_length
+                    if previousTraitCollection.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+                        self.imageHeightConstraint.constant = self.scaledImageHeight(compatibleWith: traitCollection)
+                    }
                 }
-            }
-        )
-        */
+            )
+        }
     }
 
     override func styleDidChange() {
@@ -131,5 +130,3 @@ class TipView: OCKView, OCKCardable {
         return UIFontMetrics.default.scaledValue(for: 200, compatibleWith: traitCollection)
     }
 }
-
-// swiftlint:enable line_length

--- a/OCKSample/Main/Care/CustomCards/TipView.swift
+++ b/OCKSample/Main/Care/CustomCards/TipView.swift
@@ -32,6 +32,7 @@ import UIKit
 import CareKit
 import CareKitUI
 
+// swiftlint:disable line_length
 class TipView: OCKView, OCKCardable {
 
     var cardView: UIView { self }
@@ -96,6 +97,8 @@ class TipView: OCKView, OCKCardable {
             imageHeightConstraint
         ])
 
+        // BAKER: Required if building for iOS 18+.
+        /*
         registerForTraitChanges(
             [UITraitPreferredContentSizeCategory.self],
             handler: { (self: Self, previousTraitCollection: UITraitCollection) in
@@ -106,10 +109,7 @@ class TipView: OCKView, OCKCardable {
                 }
             }
         )
-    }
-
-    func scaledImageHeight(compatibleWith traitCollection: UITraitCollection) -> CGFloat {
-        return UIFontMetrics.default.scaledValue(for: 200, compatibleWith: traitCollection)
+        */
     }
 
     override func styleDidChange() {
@@ -118,4 +118,18 @@ class TipView: OCKView, OCKCardable {
         enableCardStyling(true, style: cachedStyle)
         directionalLayoutMargins = cachedStyle.dimension.directionalInsets1
     }
+
+    // BAKER: Remove if building for iOS 18+.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            imageHeightConstraint.constant = scaledImageHeight(compatibleWith: traitCollection)
+        }
+    }
+
+    func scaledImageHeight(compatibleWith traitCollection: UITraitCollection) -> CGFloat {
+        return UIFontMetrics.default.scaledValue(for: 200, compatibleWith: traitCollection)
+    }
 }
+
+// swiftlint:enable line_length

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CareKitSample+ParseCareKit
-![Swift](https://img.shields.io/badge/swift-5.10-brightgreen.svg) ![Xcode 16.0+](https://img.shields.io/badge/xcode-16.0%2B-blue.svg) ![iOS 18.0+](https://img.shields.io/badge/iOS-18.0%2B-blue.svg) ![watchOS 11.0+](https://img.shields.io/badge/watchOS-11.0%2B-blue.svg) ![CareKit 3.0+](https://img.shields.io/badge/CareKit-3.0%2B-red.svg) ![ci](https://github.com/netreconlab/CareKitSample-ParseCareKit/workflows/ci/badge.svg?branch=main)
+![Swift](https://img.shields.io/badge/swift-5.10-brightgreen.svg) ![Xcode 16.0+](https://img.shields.io/badge/xcode-16.0%2B-blue.svg) ![iOS 16.0+](https://img.shields.io/badge/iOS-16.0%2B-blue.svg) ![watchOS 9.0+](https://img.shields.io/badge/watchOS-9.0%2B-blue.svg) ![CareKit 3.0+](https://img.shields.io/badge/CareKit-3.0%2B-red.svg) ![ci](https://github.com/netreconlab/CareKitSample-ParseCareKit/workflows/ci/badge.svg?branch=main)
 
 An example application of [CareKit](https://github.com/carekit-apple/CareKit)'s OCKSample synchronizing CareKit data to the Cloud via [ParseCareKit](https://github.com/netreconlab/ParseCareKit). This project also depends on [CareKitEssentials](https://github.com/netreconlab/CareKitEssentials), which adds a number of views and APIs to make using CareKit easier.
 


### PR DESCRIPTION
- [x] Update to https://github.com/netreconlab/CareKitEssentials/pull/33
- [x] Drop deployment targets to [minimum supported by CareKitEssentials](https://github.com/netreconlab/CareKitEssentials/blob/6e9cb497b977433fa5b862c14b0405838898132a/Package.swift#L7)
- [x] Add back old code https://github.com/netreconlab/CareKitSample-ParseCareKit/blob/cd6d1b7c554e863a7ca20479c292cb5203fba80e/OCKSample/Main/Care/CustomCards/TipView.swift#L106-L111 