### PR TITLE
feat: Add the ability to populate data for past days

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -1295,7 +1295,7 @@
 			repositoryURL = "https://github.com/netreconlab/CareKitEssentials";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "1.0.0-alpha.54";
+				minimumVersion = "1.0.0-alpha.55";
 			};
 		};
 		70202EBF2807333900CF73FB /* XCRemoteSwiftPackageReference "CareKit" */ = {

--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -1289,7 +1289,7 @@
 			repositoryURL = "https://github.com/netreconlab/CareKitEssentials";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "1.0.0-alpha.52";
+				minimumVersion = "1.0.0-alpha.54";
 			};
 		};
 		70202EBF2807333900CF73FB /* XCRemoteSwiftPackageReference "CareKit" */ = {
@@ -1305,7 +1305,7 @@
 			repositoryURL = "https://github.com/netreconlab/ParseCareKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = "1.0.0-beta.9";
+				minimumVersion = "1.0.0-beta.10";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		707CC717254DA91900116728 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 707CC711254DA91900116728 /* Localizable.stringsdict */; };
 		707CC718254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
 		707CC719254DA91900116728 /* OCKLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CC713254DA91900116728 /* OCKLocalization.swift */; };
+		707D28CF2DCA8AAB00980253 /* OCKStore+SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28CE2DCA8AA500980253 /* OCKStore+SampleData.swift */; };
+		707D28D02DCA8AAB00980253 /* OCKStore+SampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707D28CE2DCA8AA500980253 /* OCKStore+SampleData.swift */; };
 		7083A856279CA40A00B3832E /* PCKUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083A855279CA40A00B3832E /* PCKUtility.swift */; };
 		7083A857279CA40F00B3832E /* PCKUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7083A855279CA40A00B3832E /* PCKUtility.swift */; };
 		708542F9276687F90029E888 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F6343923D2877B00FE576E /* HealthKit.framework */; };
@@ -181,6 +183,7 @@
 		707CC710254DA91900116728 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		707CC712254DA91900116728 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		707CC713254DA91900116728 /* OCKLocalization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCKLocalization.swift; sourceTree = "<group>"; };
+		707D28CE2DCA8AA500980253 /* OCKStore+SampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OCKStore+SampleData.swift"; sourceTree = "<group>"; };
 		7083A855279CA40A00B3832E /* PCKUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCKUtility.swift; sourceTree = "<group>"; };
 		7099D1FE29E98D900037CD8E /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
 		7099D20429E98DFF0037CD8E /* TaskID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskID.swift; sourceTree = "<group>"; };
@@ -485,6 +488,7 @@
 				70F03A942786093B00E5AFB4 /* OCKHealthKitPassthroughStore.swift */,
 				70F03AA227860AFF00E5AFB4 /* OCKPatient+Parse.swift */,
 				70F03A962786098F00E5AFB4 /* OCKStore.swift */,
+				707D28CE2DCA8AA500980253 /* OCKStore+SampleData.swift */,
 				7083A855279CA40A00B3832E /* PCKUtility.swift */,
 			);
 			path = Extensions;
@@ -778,6 +782,7 @@
 				70F921A927CA9A4000368CEC /* CustomStylerKey.swift in Sources */,
 				7099D20629E98DFF0037CD8E /* TaskID.swift in Sources */,
 				7075151E28DE1A8300A57A0C /* MainView.swift in Sources */,
+				707D28D02DCA8AAB00980253 /* OCKStore+SampleData.swift in Sources */,
 				70A98D62278A2683009B58F2 /* Styler.swift in Sources */,
 				91693818271B5E1600A634ED /* Constants.swift in Sources */,
 				70E3422B2DB0581C005124F9 /* MainTabView.swift in Sources */,
@@ -824,6 +829,7 @@
 				7036E4CE256E9A0C006E9A3C /* ContactView.swift in Sources */,
 				70F03A972786098F00E5AFB4 /* OCKStore.swift in Sources */,
 				70DFD80B2567074500B9DB12 /* LoginView.swift in Sources */,
+				707D28CF2DCA8AAB00980253 /* OCKStore+SampleData.swift in Sources */,
 				7055725B2DC33AB1008E5B0A /* SplashScreenView.swift in Sources */,
 				70F03AA827860E7700E5AFB4 /* FontColorKey.swift in Sources */,
 				9169381B271B64E100A634ED /* Styler.swift in Sources */,

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/CareKitEssentials",
       "state" : {
-        "revision" : "6bddb504f64a86514c35a80218702dd356936b06",
-        "version" : "1.0.0-alpha.54"
+        "revision" : "a4585fb65bb1c4dbb94fef2c5a1163c8acd68d71",
+        "version" : "1.0.0-alpha.55"
       }
     },
     {

--- a/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OCKSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/CareKitEssentials",
       "state" : {
-        "revision" : "695a8d3c4d6e9a04bc771d2c55bb1696cc525dca",
-        "version" : "1.0.0-alpha.52"
+        "revision" : "6bddb504f64a86514c35a80218702dd356936b06",
+        "version" : "1.0.0-alpha.54"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/netreconlab/ParseCareKit.git",
       "state" : {
-        "revision" : "2e7d27f54d43a6a924232ccd0accae14c0179a9f",
-        "version" : "1.0.0-beta.9"
+        "revision" : "1efa23525094be67b87ae1c1102fa574978636b2",
+        "version" : "1.0.0-beta.10"
       }
     },
     {

--- a/OCKSample/AppDelegate.swift
+++ b/OCKSample/AppDelegate.swift
@@ -84,8 +84,10 @@ class AppDelegate: UIResponder, ObservableObject {
         healthKitStore = nil
         parseRemote = nil
 
-        let store = OCKStore(name: Constants.noCareStoreName,
-                             type: .inMemory)
+        let store = OCKStore(
+			name: Constants.noCareStoreName,
+			type: .inMemory
+		)
         sessionDelegate.store = store
         self.store = store
         PCKUtility.removeCache()

--- a/OCKSample/Constants.swift
+++ b/OCKSample/Constants.swift
@@ -24,6 +24,13 @@ let isSyncingWithRemote = true
  */
 let isSendingPushUpdatesToWatch = true
 
+/**
+ If you want to generate sample data for x amount of days in the past (before user sign-up),
+ set this value to a negative number. This is used for demo purposes if you want populate
+ the InsightsView charts with data.
+ */
+let daysInThePastToGenerateSampleData: Int = 0 // Should be a negative number, for example -30, for the past 30 days.
+
 enum Constants {
     static let parseConfigFileName = "ParseCareKit"
     static let iOSParseCareStoreName = "iOSParseStore"

--- a/OCKSample/Extensions/AppDelegate+UIApplicationDelegate.swift
+++ b/OCKSample/Extensions/AppDelegate+UIApplicationDelegate.swift
@@ -49,8 +49,8 @@ extension AppDelegate: UIApplicationDelegate {
                 // When syncing directly with watchOS, we do not care about login and need to setup remotes
                 do {
                     try await setupRemotes()
-                    try await store.populateSampleData()
-                    try await healthKitStore.populateSampleData()
+                    try await store.populateDefaultCarePlansTasksContacts()
+                    try await healthKitStore.populateDefaultHealthKitTasks()
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                         NotificationCenter.default.post(.init(name: Notification.Name(rawValue: Constants.requestSync)))
                         Utility.requestHealthKitPermissions()

--- a/OCKSample/Extensions/OCKHealthKitPassthroughStore.swift
+++ b/OCKSample/Extensions/OCKHealthKitPassthroughStore.swift
@@ -14,7 +14,9 @@ import os.log
 
 extension OCKHealthKitPassthroughStore {
 
-    func populateSampleData() async throws {
+    func populateDefaultHealthKitTasks(
+		startDate: Date = Date()
+	) async throws {
 
         let countUnit = HKUnit.count()
         let stepTargetValue = OCKOutcomeValue(
@@ -25,7 +27,7 @@ extension OCKHealthKitPassthroughStore {
         let stepSchedule = OCKSchedule.dailyAtTime(
             hour: 8,
             minutes: 0,
-            start: Date(),
+            start: startDate,
             end: nil,
             text: nil,
             duration: .allDay,
@@ -47,7 +49,7 @@ extension OCKHealthKitPassthroughStore {
         let ovulationTestResultSchedule = OCKSchedule.dailyAtTime(
             hour: 8,
             minutes: 0,
-            start: Date(),
+            start: startDate,
             end: nil,
             text: nil,
             duration: .allDay,

--- a/OCKSample/Extensions/OCKStore+SampleData.swift
+++ b/OCKSample/Extensions/OCKStore+SampleData.swift
@@ -1,0 +1,146 @@
+//
+//  OCKStore+SampleData.swift
+//  OCKSample
+//
+//  Created by Corey Baker on 5/6/25.
+//  Copyright © 2025 Network Reconnaissance Lab. All rights reserved.
+//
+
+import CareKitStore
+import Foundation
+import os.log
+
+extension OCKStore {
+	func populateSampleOutcomes(
+		startDate: Date
+	) async throws {
+
+		// Prepare previous samples.
+		let yesterDay = Calendar.current.date(
+			byAdding: .day,
+			value: -1,
+			to: Date()
+		)!.endOfDay
+		guard yesterDay > startDate else {
+			throw AppError.errorString("Start date must be before last night")
+		}
+		let dateInterval = DateInterval(
+			start: startDate,
+			end: yesterDay
+		)
+		let eventQuery = OCKEventQuery(
+			dateInterval: dateInterval
+		)
+		let pastEvents = try await fetchEvents(query: eventQuery)
+		let pastOutcomes = pastEvents.compactMap { event -> OCKOutcome? in
+
+			let initialRandomDate = randomDate(
+				event.scheduleEvent.start,
+				end: event.scheduleEvent.end
+			)
+
+			switch event.task.id {
+			case TaskID.doxylamine, TaskID.kegels, TaskID.stretch:
+				let randomBool: Bool = .random()
+				guard randomBool else { return nil }
+				let outcomeValue = createOutcomeValue(
+					randomBool,
+					createdDate: initialRandomDate
+				)
+
+				let outcome = addValueToOutcome(
+					[outcomeValue],
+					for: event
+				)
+				return outcome
+			case TaskID.nausea:
+				// multiple random bools
+				let outcomeValues = (0...3).compactMap { _ -> OCKOutcomeValue? in
+					let randomBool: Bool = .random()
+					guard randomBool else { return nil }
+					let randomDate = randomDate(
+						event.scheduleEvent.start,
+						end: event.scheduleEvent.end
+					)
+					let outcomeValue = createOutcomeValue(
+						randomBool,
+						createdDate: randomDate
+					)
+
+					return outcomeValue
+				}
+
+				let outcome = addValueToOutcome(
+					outcomeValues,
+					for: event
+				)
+				return outcome
+
+			default:
+				return nil
+			}
+		}
+
+		do {
+			let savedOutcomes = try await addOutcomes(pastOutcomes)
+			Logger.ockStore.info("Added sample \(savedOutcomes.count) outcomes to OCKStore!")
+		} catch {
+			Logger.ockStore.error("Error adding sample outcomes: \(error)")
+		}
+	}
+
+	private func createOutcomeValue(
+		_ value: OCKOutcomeValueUnderlyingType,
+		createdDate: Date
+	) -> OCKOutcomeValue {
+		var outcomeValue = OCKOutcomeValue(
+			value
+		)
+		outcomeValue.createdDate = createdDate
+		return outcomeValue
+	}
+
+	private func addValueToOutcome(
+		_ values: [OCKOutcomeValue],
+		for event: OCKEvent<OCKTask, OCKOutcome>
+	) -> OCKOutcome? {
+
+		guard !values.isEmpty else {
+			// Act like nothing was submitted.
+			return nil
+		}
+
+		guard var outcome = event.outcome else {
+			// Event doesn't have an outcome, need to
+			// create a new one that exists in the past.
+			var newOutcome = OCKOutcome(
+				taskUUID: event.task.uuid,
+				taskOccurrenceIndex: event.scheduleEvent.occurrence,
+				values: values
+			)
+
+			let effectiveDate = newOutcome
+				.sortedOutcomeValuesByRecency()
+				.values
+				.last?.createdDate ?? event.scheduleEvent.start
+
+			newOutcome.effectiveDate = effectiveDate
+			return newOutcome
+		}
+
+		outcome.values.append(contentsOf: values)
+		let effectiveDate = outcome
+			.sortedOutcomeValuesByRecency()
+			.values
+			.last?.createdDate ?? event.scheduleEvent.start
+		outcome.effectiveDate = effectiveDate
+		return outcome
+	}
+
+	private func randomDate(_ startDate: Date, end endDate: Date) -> Date {
+		let timeIntervalRange = startDate.timeIntervalSince1970..<endDate.timeIntervalSince1970
+		let randomTimeInterval = TimeInterval.random(in: timeIntervalRange)
+		let randomDate = Date(timeIntervalSince1970: randomTimeInterval)
+		return randomDate
+	}
+}

--- a/OCKSample/Extensions/OCKStore.swift
+++ b/OCKSample/Extensions/OCKStore.swift
@@ -43,9 +43,11 @@ extension OCKStore {
     }
 
     // Adds tasks and contacts into the store
-    func populateSampleData() async throws {
+    func populateDefaultCarePlansTasksContacts(
+		startDate: Date = Date()
+	) async throws {
 
-        let thisMorning = Calendar.current.startOfDay(for: Date())
+        let thisMorning = Calendar.current.startOfDay(for: startDate)
         let aFewDaysAgo = Calendar.current.date(byAdding: .day, value: -4, to: thisMorning)!
         let beforeBreakfast = Calendar.current.date(byAdding: .hour, value: 8, to: aFewDaysAgo)!
         let afterLunch = Calendar.current.date(byAdding: .hour, value: 14, to: aFewDaysAgo)!

--- a/OCKSample/Main/Login/LoginViewModel.swift
+++ b/OCKSample/Main/Login/LoginViewModel.swift
@@ -119,8 +119,24 @@ class LoginViewModel: ObservableObject {
                                     familyName: lastName)
         newPatient.userType = type
         let savedPatient = try await appDelegate.store.addPatient(newPatient)
-        try await appDelegate.store.populateSampleData()
-        try await appDelegate.healthKitStore.populateSampleData()
+
+		let currentDate = Date()
+		let startDate = daysInThePastToGenerateSampleData < 0 ? Calendar.current.date(
+			byAdding: .day,
+			value: daysInThePastToGenerateSampleData,
+			to: currentDate
+		)! : currentDate
+        try await appDelegate.store.populateDefaultCarePlansTasksContacts(
+			startDate: startDate
+		)
+        try await appDelegate.healthKitStore.populateDefaultHealthKitTasks(
+			startDate: startDate
+		)
+		if startDate < currentDate {
+			try await appDelegate.store.populateSampleOutcomes(
+				startDate: startDate
+			)
+		}
         appDelegate.parseRemote.automaticallySynchronizes = true
 
         // Post notification to sync

--- a/OCKSample/Utility.swift
+++ b/OCKSample/Utility.swift
@@ -112,14 +112,28 @@ class Utility {
                 // If patient exists, assume store is already populated
                 _ = try await store.fetchPatient(withID: patientId)
             } catch {
-                var patient = OCKPatient(id: patientId,
-                                         givenName: "Preview",
-                                         familyName: "Patient")
-                patient.birthday = Calendar.current.date(byAdding: .year,
-                                                         value: -20,
-                                                         to: Date())
+                var patient = OCKPatient(
+					id: patientId,
+					givenName: "Preview",
+					familyName: "Patient"
+				)
+                patient.birthday = Calendar.current.date(
+					byAdding: .year,
+					value: -20,
+					to: Date()
+				)
                 _ = try? await store.addPatient(patient)
-                try? await store.populateSampleData()
+				let startDate = Calendar.current.date(
+					byAdding: .day,
+					value: -30,
+					to: Date()
+				)!
+                try? await store.populateDefaultCarePlansTasksContacts(
+					startDate: startDate
+				)
+				try? await store.populateSampleOutcomes(
+					startDate: startDate
+				)
             }
         }
         return store

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ An example application of [CareKit](https://github.com/carekit-apple/CareKit)'s 
 
 **Similar to the [What's New in CareKit](https://developer.apple.com/videos/play/wwdc2020/10151/) WWDC20 video, this app syncs data between iOS and an Apple Watch (setting the flag `isSyncingWithRemote` in `Constants.swift` to `isSyncingWithRemote = false.` Different from the video, setting `isSyncingWithRemote = true` (default behavior) in the aforementioned file syncs iOS and watchOS to a Parse Server.**
 
+**If you want to populate random sample OCKOutcomes for events in the past, for example to view data in the InsightsView when testing, set 
+`daysInThePastToGenerateSampleData` to a negative number in `Constants.swift`.
+
 ParseCareKit synchronizes the following entities to Parse tables/classes using [Parse-Swift](https://github.com/netreconlab/Parse-Swift):
 
 - [x] OCKPatient <-> Patient

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An example application of [CareKit](https://github.com/carekit-apple/CareKit)'s 
 **Similar to the [What's New in CareKit](https://developer.apple.com/videos/play/wwdc2020/10151/) WWDC20 video, this app syncs data between iOS and an Apple Watch (setting the flag `isSyncingWithRemote` in `Constants.swift` to `isSyncingWithRemote = false.` Different from the video, setting `isSyncingWithRemote = true` (default behavior) in the aforementioned file syncs iOS and watchOS to a Parse Server.**
 
 **If you want to populate random sample OCKOutcomes for events in the past, for example to view data in the InsightsView when testing, set 
-`daysInThePastToGenerateSampleData` to a negative number in `Constants.swift`.
+`daysInThePastToGenerateSampleData` to a negative number in `Constants.swift`.**
 
 ParseCareKit synchronizes the following entities to Parse tables/classes using [Parse-Swift](https://github.com/netreconlab/Parse-Swift):
 


### PR DESCRIPTION
- [x] Add the ability to populate sample outcome values in the past for testing by setting `daysInThePastToGenerateSampleData` in `Constants.swift` to a negative number
- [x] Automatically populate sample outcomes when using Previews in Xcode
- [x] Bump to latest CareKitEssentials and ParseCareKit  