### PR TITLE
fix: Local patient not syncing after profile update

### DIFF
--- a/OCKSample/Main/Profile/ProfileViewModel.swift
+++ b/OCKSample/Main/Profile/ProfileViewModel.swift
@@ -69,8 +69,13 @@ class ProfileViewModel: ObservableObject {
         }
 
         if patientHasBeenUpdated {
-            _ = try await AppDelegateKey.defaultValue?.store.updatePatient(patientToUpdate)
-            Logger.profile.info("Successfully updated patient")
+            if let anyPatient = try await AppDelegateKey.defaultValue?.store.updateAnyPatient(patientToUpdate),
+               let updatedPatient = anyPatient as? OCKPatient {
+                self.patient = updatedPatient
+                Logger.profile.info("Successfully updated patient and synced local state.")
+            } else {
+                Logger.profile.error("Patient was updated in store but could not be cast to OCKPatient.")
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates the logic in `ProfileViewModel.saveProfile()` to ensure that the local patient property stays in sync with the backend after saving.

Specifically, it uses `store.updateAnyPatient(...)` and casts the result back to `OCKPatient`, then assigns it to `self.patient` to trigger the willSet block and properly refresh local fields such as `firstName`, `lastName`, `birthday`, etc.

- [x]  Fixes an issue where local patient data was not updated after a successful backend save

